### PR TITLE
Add unittest to IPMI poller job

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -54,6 +54,7 @@ function ipmiJobFactory(
 
         this.concurrent = {};
         this.cachedPowerState = {};
+        this.cachedPowerStatus = "";
     }
     util.inherits(IpmiJob, BaseJob);
 
@@ -75,6 +76,8 @@ function ipmiJobFactory(
                 self.createCallback('sdr', self.collectIpmiSdr.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'chassis',
                 self.createCallback('chassis', self.collectIpmiChassis.bind(self)));
+	    self._subscribeRunIpmiCommand(self.routingKey, 'powerStatus',
+		self.createCallback('powerStatus', self.collectpowerStatus.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'driveHealth',
                 self.createCallback('driveHealth', self.collectIpmiDriveHealth.bind(self)));
         })
@@ -100,6 +103,7 @@ function ipmiJobFactory(
                 sel: 0,
                 chassis: 0,
                 driveHealth: 0,
+                powerStatus: 0,
                 selEntries: 0
             };
         }
@@ -452,6 +456,40 @@ function ipmiJobFactory(
         });
     };
 
+     IpmiJob.prototype.powerStatusAlerter = Promise.method(function(powerStatus, data) {
+        var self = this;
+        var tmp = {};
+        tmp.type = 'polleralert';
+        tmp.action = 'powerstatus.updated';
+        tmp.typeId = data.workItemId;
+        tmp.nodeId = data.node;
+        tmp.severity = "information";
+        tmp.data = {
+            states: {
+                last: self.cachedPowerStatus,
+                current: powerStatus["powerStatus"]
+            }
+        };
+         if (self.cachedPowerStatus !== powerStatus["powerStatus"]) { 
+            if (self.cachedPowerStatus !== ""){
+                self._publishPollerAlert(tmp);
+            }
+            self.cachedPowerStatus = powerStatus["powerStatus"];
+        }
+        return powerStatus;
+    });
+
+    IpmiJob.prototype.collectpowerStatus = function(data) {
+        var self = this;
+        return ipmitool.powerStatus(data.host, data.user, data.password)
+        .then(function(powerStatus) {
+            return [ parser.parsePowerStatusData(powerStatus), data ];
+        })
+        .spread(self.powerStatusAlerter.bind(self))
+        .then(function(powerStatus){
+           return powerStatus;
+        });
+    };
     /**
      * Collect drive health status data from IPMI
      * @memberOf IpmiJob

--- a/lib/jobs/message-cache-job.js
+++ b/lib/jobs/message-cache-job.js
@@ -89,7 +89,8 @@ function pollerMessageCacheJobFactory(
                    'selInformation', 
                    'sel', 
                    'selEntries', 
-                   'chassis', 
+                   'chassis',
+                   'powerStatus', 
                    'driveHealth'], 
             function(command) {
             self._subscribeIpmiCommandResult(

--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -44,6 +44,10 @@ function parseSensorsDataFactory(assert, _) {
             if(sensorInfo.length < 3) {
                 sensorInfo.push('00');
             }
+            if(rows[1].indexOf('Pre-Init') > -1) {
+                rows[1] = "";
+                rows[2] = "";
+            }
             var kv = {
                 logId: rows[0],
                 date: rows[1],
@@ -276,7 +280,7 @@ function parseSensorsDataFactory(assert, _) {
     }
     
     /**
-     * parse/extract text output from IPMI call into a list of power status
+     * parse/extract text output from IPMI call into power status
      */
     function parsePowerStatusData(powerStatusData) {
        var word = powerStatusData.trim().split(' ');

--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -44,10 +44,6 @@ function parseSensorsDataFactory(assert, _) {
             if(sensorInfo.length < 3) {
                 sensorInfo.push('00');
             }
-            if(rows[1].indexOf('Pre-Init') > -1) {
-                rows[1] = "";
-                rows[2] = "";
-            }
             var kv = {
                 logId: rows[0],
                 date: rows[1],
@@ -278,7 +274,15 @@ function parseSensorsDataFactory(assert, _) {
             power: (powerCode & 0x1) === 1
         };
     }
-
+    
+    /**
+     * parse/extract text output from IPMI call into a list of power status
+     */
+    function parsePowerStatusData(powerStatusData) {
+       var word = powerStatusData.trim().split(' ');
+       return {powerStatus: word[3]
+       };
+    }
     /**
      * parse/extract text output from IPMI call into a list of drive health status
      *
@@ -307,6 +311,7 @@ function parseSensorsDataFactory(assert, _) {
         parseSelDataEntries: parseSelDataEntries,
         parseSdrData: parseSdrData,
         parseChassisData: parseChassisData,
+        parsePowerStatusData: parsePowerStatusData,
         parseDriveHealthData: parseDriveHealthData
     };
 }

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -165,14 +165,15 @@ describe(require('path').basename(__filename), function () {
        
         it("should return powerStatus", function() {
             var self = this;
-            var testState ='off';
+            var testResult = { powerStatus: 'on' };
             var data = {host:"172.31.128.4",user: "admin", password:"Password1"};
-            self.ipmi.powerStatus = this.sandbox.stub().resolves("Power State is off");
-            parser.parsePowerStatusData = this.sandbox.stub().resolves("off");
+            this.ipmi.powerStatus = this.sandbox.stub().resolves("Power State is on");
+            //parser.parsePowerStatusData = this.sandbox.stub().resolves("off");
+            this.sandbox.spy(parser, 'parsePowerStatusData')
             this.sandbox.spy(self.ipmi, 'powerStatusAlerter')
             return self.ipmi.collectpowerStatus(data)
                 .then(function(status) {
-                    expect(status).to.equal(testState);
+                    expect(status).to.deep.equal(testResult);
                     expect(self.ipmi.powerStatusAlerter).to.have.been.calledOnec;         
                     expect(parser.parsePowerStatusData).to.have.been.calledOnce;
                 });

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -162,12 +162,25 @@ describe(require('path').basename(__filename), function () {
                     expect(self.ipmi.cachedPowerStatus).to.equal(testState.powerStatus);
                 });
         });
-       
+      
+        it("should not send powerStatus Change alert at begining", function() {
+            var self = this;
+            var testState ={powerStatus: 'off'}
+            var testData = {workItemId: 'abc', node:"unittestnode"};
+            self.ipmi.cachedPowerStatus = '';
+            return self.ipmi.powerStatusAlerter(testState, testData)
+                .then(function(status) {
+                    expect(self.ipmi._publishPollerAlert).to.not.be.called;
+                    expect(status).to.deep.equal(testState);
+                    expect(self.ipmi.cachedPowerStatus).to.equal(testState.powerStatus);
+                });
+        });
+ 
         it("should return powerStatus", function() {
             var self = this;
-            var testResult = { powerStatus: 'on' };
+            var testResult = { powerStatus: 'off' };
             var data = {host:"172.31.128.4",user: "admin", password:"Password1"};
-            this.ipmi.powerStatus = this.sandbox.stub().resolves("Power State is on");
+            this.ipmi.powerStatus = this.sandbox.stub().resolves("Power State is off");
             //parser.parsePowerStatusData = this.sandbox.stub().resolves("off");
             this.sandbox.spy(parser, 'parsePowerStatusData')
             this.sandbox.spy(self.ipmi, 'powerStatusAlerter')


### PR DESCRIPTION
Details:
This PR is just for experiment. It add a Chassis IPMI poller and the unit test. The unit test includes both positive and negative test.
![ipmipo](https://user-images.githubusercontent.com/14198260/29353048-7b4f70b8-829b-11e7-86a6-0019ff411899.png)

Result:
Unit test is pass. Coverage of ipmi-job.js is:
Statements   : 34.75% ( 572/1646 )
Branches     : 11.06% ( 45/407 )
Functions    : 19.26% ( 89/462 )
Lines        : 34.77% ( 572/1645 )
